### PR TITLE
remove pony-stable requirement for examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ docs: $(DEPS) $(TEST_DEPS)
 
 example: $(EXAMPLE_DEPS)
 	cd examples && \
-	    stable fetch && \
-	    CC=$(CC) stable env $(PONYC) $(FLAGS)
+	    CC=$(CC) $(PONYC) $(FLAGS)
 
 .PHONY: fetch

--- a/examples/bundle.json
+++ b/examples/bundle.json
@@ -1,8 +1,0 @@
-{
-  "deps": [
-    {
-      "type": "local-git",
-      "local-path": ".."
-    }
-  ]
-}

--- a/examples/list_reverse.pony
+++ b/examples/list_reverse.pony
@@ -1,7 +1,7 @@
-
-use "ponycheck"
 use "ponytest"
 use "collections"
+use "../ponycheck"
+
 actor Main is TestList
     new create(env: Env) =>
         PonyTest(env, this)


### PR DESCRIPTION
ponyc allows relative paths in `use` declarations, so there is no need to depend on pony-stable. Also, this is project is really cool!