### PR TITLE
improve generator API

### DIFF
--- a/examples/list_reverse.pony
+++ b/examples/list_reverse.pony
@@ -13,36 +13,36 @@ actor Main is TestList
     test(_ListReverseOneProperty)
     test(_ListReverseMultipleProperties)
 
-class _ListReverseProperty is Property1[List[USize]]
+class _ListReverseProperty is Property1[Array[USize]]
   fun name(): String => "list/reverse"
 
-  fun gen(): Generator[List[USize]] =>
-    Generators.listOf[USize](Generators.uSize())
+  fun gen(): Generator[Array[USize]] =>
+    Generators.seq_of[USize, Array[USize]](Generators.usize())
 
-  fun property(arg1: List[USize], ph: PropertyHelper) =>
+  fun property(arg1: Array[USize], ph: PropertyHelper) =>
     ph.assert_array_eq[USize](arg1, arg1.reverse().reverse())
 
-
-class _ListReverseOneProperty is Property1[List[USize]]
+class _ListReverseOneProperty is Property1[Array[USize]]
   fun name(): String => "list/reverse/one"
 
-  fun gen(): Generator[List[USize]] =>
-    Generators.listOfN[USize](1, Generators.uSize())
+  fun gen(): Generator[Array[USize]] =>
+    Generators.seq_of[USize, Array[USize]](Generators.usize(), 1, 1)
 
-  fun property(arg1: List[USize], ph: PropertyHelper) =>
+  fun property(arg1: Array[USize], ph: PropertyHelper) =>
+    ph.assert_eq[USize](arg1.size(), 1)
     ph.assert_array_eq[USize](arg1, arg1.reverse())
 
 class _ListReverseMultipleProperties is UnitTest
   fun name(): String => "list/properties"
 
   fun apply(h: TestHelper) ? =>
-    let gen1 = Generators.listOf[USize](Generators.uSize())
-    Ponycheck.forAll[List[USize]](gen1, h)({
-      (arg1: List[USize], ph: PropertyHelper) =>
+    let gen1 = Generators.seq_of[USize, Array[USize]](Generators.usize())
+    Ponycheck.forAll[Array[USize]](gen1, h)(
+      {(arg1: Array[USize], ph: PropertyHelper) =>
         ph.assert_array_eq[USize](arg1, arg1.reverse().reverse())
-    })?
-    let gen2 = Generators.listOfN[USize](1, Generators.uSize())
-      Ponycheck.forAll[List[USize]](gen2, h)({
-        (arg1: List[USize], ph: PropertyHelper) =>
+      })?
+    let gen2 = Generators.seq_of[USize, Array[USize]](Generators.usize(), 1, 1)
+      Ponycheck.forAll[Array[USize]](gen2, h)(
+        {(arg1: Array[USize], ph: PropertyHelper) =>
           ph.assert_array_eq[USize](arg1, arg1.reverse())
-    })?
+        })?

--- a/ponycheck/ponycheck.pony
+++ b/ponycheck/ponycheck.pony
@@ -8,14 +8,13 @@ use "collections"
 use "ponycheck"
 
 class ListReverseProperty is Property1[List[USize]]
-
   fun name(): String => "list/reverse"
 
-  fun gen(): Generator[List[USize]] => Generators.listOf[USize](Generators.uSize())
+  fun gen(): Generator[List[USize]] =>
+    Generators.list_of[USize](Generators.usize())
 
   fun property(arg1: List[USize], ph: PropertyHelper) =>
-    ph.array_eq[Usize](arg1, arg1.reverse().reverse())
-
+    ph.array_eq[USize](arg1, arg1.reverse().reverse())
 ```
 
 A property based test in ponytest consists of the following:
@@ -37,10 +36,11 @@ class ListReversePropertyWithinAUnitTest is UnitTest
 
   fun apply(h: TestHelper) =>
     let gen = Generators.listOf[USize](Generators.uSize())
-    Ponycheck.forAll[List[USize]](gen, h)({(sample: List[USize], ph: PropertyHelper) =>
-      ph.array_eq[Usize](arg1, arg1.reverse().reverse())
-    })
-    // ... possibly more properties, using ``Ponycheck.forAll``
+    Ponycheck.forAll[List[USize]](gen, h)(
+      {(sample: List[USize], ph: PropertyHelper) =>
+        ph.array_eq[Usize](arg1, arg1.reverse().reverse())
+      })
+    // ... possibly more properties, using ``Ponycheck.for_all``
 ```
 
 

--- a/ponycheck/property_helper.pony
+++ b/ponycheck/property_helper.pony
@@ -1,5 +1,7 @@
 use "ponytest"
 
+// TODO append strings instead of add
+
 interface FailureCallback
   """something to call in case of error"""
   fun fail(msg: String)
@@ -324,15 +326,13 @@ class ref PropertyHelper
   fun tag _format_params(params: PropertyParams): String =>
     "Params(seed=" + params.seed.string() + ")"
 
-
   fun reportSuccess() =>
     """
     report success to the property test runner
     """
 
-
-  fun reportError(sampleRepr: String,
-    shrinkRounds: USize = 0,
+  fun reportError(sample_repr: String,
+    shrink_rounds: USize = 0,
     loc: SourceLoc = __loc) =>
     """
     report an error that happened during property evaluation
@@ -341,16 +341,16 @@ class ref PropertyHelper
       _fmt_msg(
         loc,
         "Property errored for sample "
-          + sampleRepr
+          + sample_repr
           + " (after "
-          + shrinkRounds.string()
+          + shrink_rounds.string()
           + " shrinks)"
       ),
       false
     )
 
-  fun reportFailed[T](sampleRepr: String,
-    shrinkRounds: USize = 0,
+  fun reportFailed[T](sample_repr: String,
+    shrink_rounds: USize = 0,
     loc: SourceLoc = __loc) =>
     """
     report a failed property
@@ -359,9 +359,9 @@ class ref PropertyHelper
       _fmt_msg(
         loc,
         "Property failed for sample "
-          + sampleRepr
+          + sample_repr
           + " (after "
-          + shrinkRounds.string()
+          + shrink_rounds.string()
           + " shrinks)"
       )
     )


### PR DESCRIPTION
This change provides a workaround for ponylang/ponyc#1875 and changes variable and method names from camelCase to snake_case. `map` and `flat_map` have also been added to the Generator API.
closes #8