### PR TITLE
add ``Generators.set_of`` to generate sets of random values

### DIFF
--- a/ponycheck/generator.pony
+++ b/ponycheck/generator.pony
@@ -124,7 +124,7 @@ primitive Generators
     """
     Create a generator for sets filled with values
     of the given generator ``gen``.
-    The returned sets will have a size between ``min`` and ``max``
+    The returned sets will have a size up to ``max``
     but tend to have fewer than ``max``
     depending on the feeding generator ``gen``.
 

--- a/ponycheck/generator.pony
+++ b/ponycheck/generator.pony
@@ -116,6 +116,37 @@ primitive Generators
             .collect[S](S.create(size))
       end)
 
+  fun set_of[T: (Hashable #read & Equatable[T] #read)](
+    gen: Generator[T],
+    max: USize = 100)
+    : Generator[Set[T]]
+  =>
+    """
+    Create a generator for sets filled with values
+    of the given generator ``gen``.
+    The returned sets will have a size between ``min`` and ``max``
+    but tend to have fewer than ``max``
+    depending on the feeding generator ``gen``.
+
+    E.g. if the given generator is for ``U8`` values and ``max`` is set to 1024
+    the set will only ever be of size 256 max.
+
+    Also for efficiency purposes and to not loop forever
+    this generator will only try to add at most ``max`` values to the set.
+    If there are duplicates, the set won't grow.
+    """
+    Generator[Set[T]](
+      object is GenObj[Set[T]]
+        fun generate(rnd: Randomness): Set[T]^ =>
+          let size = rnd.usize(0, max)
+          let set = Set[T](size)
+          for i in Range(0, size) do
+            set.set(gen.generate(rnd))
+          end
+          consume set
+      end)
+
+
   fun one_of[T](xs: ReadSeq[T]): Generator[box->T] ? =>
     """
     Generate a random value from the given ReadSeq. An error will be thrown

--- a/ponycheck/test/gen.pony
+++ b/ponycheck/test/gen.pony
@@ -59,7 +59,7 @@ class GenFrequencyTest is UnitTest
 
       let generated = Array[U8](100)
       for i in Range(0, 100) do
-        generated(i)? = gen.generate(rnd)
+        generated.push(gen.generate(rnd))
       end
       h.assert_false(generated.contains(U8(42)), "frequency generated value with 0 weight")
       h.assert_true(generated.contains(U8(0)), "frequency did not generate value with weight of 1")
@@ -67,3 +67,20 @@ class GenFrequencyTest is UnitTest
     else
       h.fail("error creating frequency generator")
     end
+
+class SetOfTest is UnitTest
+  fun name(): String => "Gen/set_of"
+
+  fun apply(h: TestHelper) =>
+    """
+    this mainly tests that a source generator with a smaller range
+    than max is terminating and generating sane sets
+    """
+    let set_gen =
+      Generators.set_of[U8](
+        Generators.u8(),
+        1024)
+    let rnd = Randomness(789)
+    let sample: Set[U8] = set_gen.generate(rnd)
+    h.assert_true(sample.size() <= 256, "something about U8 is not right")
+

--- a/ponycheck/test/main.pony
+++ b/ponycheck/test/main.pony
@@ -8,6 +8,8 @@ actor Main is TestList
   fun tag tests(test: PonyTest) =>
     test(GenRndTest)
     test(GenFilterTest)
+    test(GenFrequencyTest)
+    test(SetOfTest)
     test(PropertyAsUnitTest)
     test(FailingPropertyAsUnitTest)
     test(ErroringPropertyAsUnitTest)


### PR DESCRIPTION
this method does not have a min argument as it is not possible to ensure
all generated sets to have min elements and ensuring the generator terminates
(e.g. with a generator always returning the same value)