### PR TITLE
Don't fail the runner through PropertyHelper fail

### DIFF
--- a/ponycheck/property_helper.pony
+++ b/ponycheck/property_helper.pony
@@ -51,11 +51,11 @@ class ref PropertyHelper
     """
     _th.log(msg, verbose)
 
-  fun fail(msg: String = "Test failed") =>
+  fun ref fail(msg: String = "Test failed") =>
     """
     Flag the test as having failed.
     """
-    _th.fail(msg)
+    _fail(msg)
 
   fun ref assert_false(
     predicate: Bool,


### PR DESCRIPTION
I mistakenly failed the TestHelper's runner through the PropertyHelper, which is inconsistent with the other methods.