### PR TITLE
Simplify imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ run_test: test
 	./test $(TESTFLAGS)
 
 clean:
-	rm -f test
+	rm -f test $(EXAMPLES_DIR)/examples
 
 
 test: $(DEPS) $(TEST_DEPS)
@@ -32,8 +32,8 @@ docs: $(DEPS) $(TEST_DEPS)
 	CC=$(CC) $(PONYC) $(FLAGS) $(SRCDIR)
 
 examples: $(EXAMPLES_DEPS)
-	cd examples && \
+	cd $(EXAMPLES_DIR) && \
 	    CC=$(CC) $(PONYC) $(FLAGS) . && \
 	    ./examples
 
-.PHONY: examples fetch
+.PHONY: examples fetch clean

--- a/examples/custom_class.pony
+++ b/examples/custom_class.pony
@@ -1,7 +1,5 @@
 use "../ponycheck"
-use "collections"
 use "itertools"
-use "time"
 
 primitive Blue is Stringable
   fun string(): String iso^ => "blue".clone()

--- a/examples/list_reverse.pony
+++ b/examples/list_reverse.pony
@@ -1,6 +1,4 @@
 use "ponytest"
-use "itertools"
-use "collections"
 use "../ponycheck"
 
 

--- a/ponycheck/test/asunitest.pony
+++ b/ponycheck/test/asunitest.pony
@@ -1,7 +1,5 @@
 use "ponytest"
 use ".."
-use "itertools"
-use "collections"
 
 class PropertyAsUnitTest is Property1[U8]
   """

--- a/ponycheck/test/shrink.pony
+++ b/ponycheck/test/shrink.pony
@@ -1,9 +1,6 @@
 use "ponytest"
 use ".."
-use "random"
-use "time"
 use "itertools"
-use "debug"
 
 trait ShrinkTest is UnitTest
   fun shrink[T](gen: Generator[T], shrink_elem: T): Iterator[T^] =>


### PR DESCRIPTION
Properties do not need to import everything [property.pony](https://github.com/mfelsche/ponycheck/blob/master/ponycheck/property.pony#L1) needed because of this ponyc bug: https://github.com/ponylang/ponyc/issues/2150 anymore, due to the great work on #32 