### PR TITLE
Separate out Ponytest integration

### DIFF
--- a/examples/list_reverse.pony
+++ b/examples/list_reverse.pony
@@ -28,13 +28,13 @@ class _ListReverseMultipleProperties is UnitTest
     let g = Generators
 
     let gen1 = recover val g.seq_of[USize, Array[USize]](g.usize()) end
-    Ponycheck.forAll[Array[USize]](gen1, h)(
+    Ponycheck.for_all[Array[USize]](gen1, h)(
       {(arg1, ph) =>
         ph.assert_array_eq[USize](arg1, arg1.reverse().reverse())
       })
 
     let gen2 = recover val g.seq_of[USize, Array[USize]](g.usize(), 1, 1) end
-    Ponycheck.forAll[Array[USize]](gen2, h)(
+    Ponycheck.for_all[Array[USize]](gen2, h)(
       {(arg1, ph) =>
         ph.assert_array_eq[USize](arg1, arg1.reverse())
       })

--- a/examples/list_reverse.pony
+++ b/examples/list_reverse.pony
@@ -24,18 +24,18 @@ class _ListReverseOneProperty is Property1[Array[USize]]
 class _ListReverseMultipleProperties is UnitTest
   fun name(): String => "list/properties"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let g = Generators
 
     let gen1 = recover val g.seq_of[USize, Array[USize]](g.usize()) end
     Ponycheck.for_all[Array[USize]](gen1, h)(
       {(arg1, ph) =>
         ph.assert_array_eq[USize](arg1, arg1.reverse().reverse())
-      })
+      })?
 
     let gen2 = recover val g.seq_of[USize, Array[USize]](g.usize(), 1, 1) end
     Ponycheck.for_all[Array[USize]](gen2, h)(
       {(arg1, ph) =>
         ph.assert_array_eq[USize](arg1, arg1.reverse())
-      })
+      })?
 

--- a/examples/main.pony
+++ b/examples/main.pony
@@ -8,9 +8,9 @@ actor Main is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>
-    test(_ListReverseProperty.unit_test())
-    test(_ListReverseOneProperty.unit_test())
+    test(Property1UnitTest[Array[USize]](_ListReverseProperty))
+    test(Property1UnitTest[Array[USize]](_ListReverseOneProperty))
     test(_ListReverseMultipleProperties)
-    test(_CustomClassFlatMapProperty.unit_test())
-    test(_CustomClassMapProperty.unit_test())
-    test(_CustomClassCustomGeneratorProperty.unit_test())
+    test(Property1UnitTest[MyLittlePony](_CustomClassFlatMapProperty))
+    test(Property1UnitTest[MyLittlePony](_CustomClassMapProperty))
+    test(Property1UnitTest[MyLittlePony](_CustomClassCustomGeneratorProperty))

--- a/ponycheck/for_all.pony
+++ b/ponycheck/for_all.pony
@@ -11,12 +11,12 @@ class ForAll[T]
   fun ref apply(prop: {(T, PropertyHelper) ?} val) ? =>
     """execute"""
     Property1UnitTest[T](
-      (object iso is Property1[T]
+      object iso is Property1[T]
         fun name(): String => ""
 
         fun gen(): Generator[T] => _gen
 
         fun property(arg1: T, h: PropertyHelper) ? =>
           prop(consume arg1, h)?
-      end)
+      end
     ).apply(_helper)?

--- a/ponycheck/for_all.pony
+++ b/ponycheck/for_all.pony
@@ -8,14 +8,15 @@ class ForAll[T]
     _gen = gen'
     _helper = testHelper
 
-  fun ref apply(prop: {(T, PropertyHelper) ?} val) =>
+  fun ref apply(prop: {(T, PropertyHelper) ?} val) ? =>
     """execute"""
-    (object val is Property1[T]
-      fun name(): String => ""
+    Property1UnitTest[T](
+      (object iso is Property1[T]
+        fun name(): String => ""
 
-      fun gen(): Generator[T] => _gen
+        fun gen(): Generator[T] => _gen
 
-      fun property(arg1: T, h: PropertyHelper) ? =>
-        prop(consume arg1, h)?
-    end)
-      .unit_test().apply(_helper)
+        fun property(arg1: T, h: PropertyHelper) ? =>
+          prop(consume arg1, h)?
+      end)
+    ).apply(_helper)?

--- a/ponycheck/ponycheck.pony
+++ b/ponycheck/ponycheck.pony
@@ -56,7 +56,7 @@ for reporting.
 use "ponytest"
 
 primitive Ponycheck
-  fun forAll[T](gen: Generator[T] val, h: TestHelper): ForAll[T] =>
+  fun for_all[T](gen: Generator[T] val, h: TestHelper): ForAll[T] =>
     """
     convenience method for running 1 to many properties as part of
     one ponytest UnitTest.

--- a/ponycheck/ponycheck.pony
+++ b/ponycheck/ponycheck.pony
@@ -67,7 +67,7 @@ primitive Ponycheck
         fun name(): String => "mytest/withMultipleProperties"
 
         fun apply(h: TestHelper) =>
-          Ponycheck.forAll[U8](recover Generators.unit[U8](0) end, h)(
+          Ponycheck.for_all[U8](recover Generators.unit[U8](0) end, h)(
             {(u, h) =>
               h.assert_eq(u, 0)
               consume u

--- a/ponycheck/property.pony
+++ b/ponycheck/property.pony
@@ -1,7 +1,3 @@
-use "ponytest"
-
-use "itertools"
-use "collections"
 use "time"
 
 class val PropertyParams
@@ -29,8 +25,7 @@ class val PropertyParams
     max_shrink_rounds = max_shrink_rounds'
     timeout = timeout'
 
-
-trait val Property1[T]
+trait Property1[T]
   """
   A property that consumes 1 argument of type ``T``.
 
@@ -62,137 +57,10 @@ trait val Property1[T]
 
   fun params(): PropertyParams => PropertyParams
 
-  fun val gen(): Generator[T]
+  fun gen(): Generator[T]
 
-  fun val property(arg1: T, h: PropertyHelper) ?
+  fun property(arg1: T, h: PropertyHelper) ?
     """
     a method verifying that a certain property holds for all given ``arg1``
     with the help of ``PropertyHelper`` ``h``.
     """
-
-  fun val unit_test(): Property1UnitTest[T]^ =>
-    Property1UnitTest[T](this)
-
-primitive Stringify[T]
-  fun apply(t: T): (T^, String) =>
-    """turn anything into a string"""
-    let digest = (digestof t)
-    let s =
-      iftype T <: Stringable #read then
-        t.string()
-      elseif T <: ReadSeq[Stringable] #read then
-        "[" + " ".join(t.values()) + "]"
-      else
-        "<identity:" + digest.string() + ">"
-      end
-    (consume t, consume s)
-
-class iso Property1UnitTest[T] is UnitTest
-  let _prop1: Property1[T]
-
-  new iso create(p1: Property1[T]) =>
-    _prop1 = p1
-
-  fun name(): String =>
-    _prop1.name()
-
-  fun ref apply(h: TestHelper) =>
-    h.long_test(_prop1.params().timeout)
-    PropertyRunner[T](_prop1, h).run()
-
-actor PropertyRunner[T]
-  let _prop1: Property1[T]
-  let _params: PropertyParams
-  let _notify: PropertyResultNotify
-  let _rnd: Randomness
-  let _ph: PropertyHelper
-  let _gen: Generator[T]
-  var _shrinker: Iterator[T^] = _EmptyIterator[T^]
-
-  new create(p1: Property1[T], notify: PropertyResultNotify) =>
-    _prop1 = consume p1
-    _params = _prop1.params()
-    _notify = consume notify
-    _rnd = Randomness(_params.seed)
-    _ph = PropertyHelper(_params, _notify)
-    _gen = _prop1.gen()
-
-  be run(n: USize = 0) =>
-    if n == _params.num_samples then
-      complete()
-      return
-    end
-    (var sample, _shrinker) = _gen.generate_and_shrink(_rnd)
-    // create a string representation before consuming ``sample`` with property
-    (sample, let sample_repr) = Stringify[T](consume sample)
-    try
-      _prop1.property(consume sample, _ph)?
-    else
-      // report error with given sample
-      _ph.report_error(sample_repr, 0)
-      fail()
-      return
-    end
-    if _ph.failed() then
-      if not _shrinker.has_next() then
-        _notify.log("no shrinks available")
-      else
-        do_shrink(sample_repr)
-      end
-    else
-      run(n + 1)
-    end
-
-
-  be do_shrink(repr: String, rounds: USize = 0) =>
-    // the shrinking Iterator is an iterator that returns more and more
-        // shrunken samples from the generator
-    // safeguard against generators that generate huge or even infinite shrink
-    if rounds == _params.max_shrink_rounds then
-      _ph.report_failed[T](repr, rounds)
-      fail()
-      return
-    end
-    (let shrink, let shrink_repr) =
-      try
-        Stringify[T](_shrinker.next()?)
-      else
-        // no more shrink samples, report failed property
-        _ph.report_failed[T](repr, rounds)
-        fail()
-        return
-      end
-
-    _ph.reset()
-
-    try
-      _prop1.property(consume shrink, _ph)?
-    else
-      _ph.report_error(shrink_repr, rounds)
-      fail()
-      return
-    end
-
-    if not _ph.failed() then
-      // we have a sample that did not fail and thus can stop shrinking
-      _notify.log("shrink: " + shrink_repr + " did not fail")
-      _ph.report_failed[T](repr, rounds)
-      fail()
-    else
-      //_notify.log("shrink: " + shrink_repr + " did fail")
-      // we have a failing shrink sample, recurse
-      do_shrink(shrink_repr, rounds + 1)
-    end
-
-  fun ref complete() =>
-    if not _ph.failed() then
-      _ph.report_success()
-      _notify.complete(true)
-    end
-
-  fun ref fail() =>
-    _notify.complete(false)
-
-class _EmptyIterator[T]
-  fun ref has_next(): Bool => false
-  fun ref next(): T^ ? => error

--- a/ponycheck/property_helper.pony
+++ b/ponycheck/property_helper.pony
@@ -1,12 +1,25 @@
-use "ponytest"
-
 interface val PropertyResultNotify
   """stripped down interface for TestHelper as this is all we need"""
+
   fun log(msg: String, verbose: Bool = false)
+    """
+    log a message to the outside world
+    """
 
   fun fail(msg: String)
+    """
+    called when a Property has failed (did not hold for a sample)
+    or when execution errored.
+    
+    Does not necessarily denote completeness of the property execution,
+    see `complete(success: Bool)` for that purpose.
+    """
 
   fun complete(success: Bool)
+    """
+    called when the Property execution is complete
+    signalling whether it was successful or not.
+    """
 
 class ref PropertyHelper
   """
@@ -85,7 +98,7 @@ class ref PropertyHelper
     true
 
   fun ref assert_error(
-    test: ITest box,
+    test: {(): None ?} box,
     msg: String = "",
     loc: SourceLoc = __loc)
     : Bool
@@ -103,7 +116,7 @@ class ref PropertyHelper
     end
 
   fun ref assert_no_error(
-    test: ITest box,
+    test: {(): None ?} box,
     msg: String = "",
     loc: SourceLoc = __loc)
     : Bool
@@ -347,18 +360,14 @@ class ref PropertyHelper
   fun tag _format_params(params: PropertyParams): String =>
     "Params(seed=" + params.seed.string() + ")"
 
-  fun report_success() =>
-    """
-    report success to the property test runner
-    """
-
   fun report_error(sample_repr: String,
     shrink_rounds: USize = 0,
     loc: SourceLoc = __loc) =>
     """
     report an error that happened during property evaluation
+    and signal failure to the notify
     """
-    _th.log(
+    _th.fail(
       _fmt_msg(
         loc,
         "Property errored for sample "
@@ -366,15 +375,14 @@ class ref PropertyHelper
           + " (after "
           + shrink_rounds.string()
           + " shrinks)"
-      ),
-      false
+      )
     )
 
-  fun report_failed[T](sample_repr: String,
+  fun report_failed(sample_repr: String,
     shrink_rounds: USize = 0,
     loc: SourceLoc = __loc) =>
     """
-    report a failed property
+    report a failed property and signal failure to the notify
     """
     _th.fail(
       _fmt_msg(

--- a/ponycheck/property_helper.pony
+++ b/ponycheck/property_helper.pony
@@ -1,17 +1,12 @@
 use "ponytest"
 
-// TODO append strings instead of add
-
-interface FailureCallback
-  """something to call in case of error"""
-  fun fail(msg: String)
-
-interface Logger
-  """something to log messages to"""
+interface val PropertyResultNotify
+  """stripped down interface for TestHelper as this is all we need"""
   fun log(msg: String, verbose: Bool = false)
 
-type _TestLogger is (FailureCallback val & Logger val)
-  """stripped down interface for TestHelper as this is all we need"""
+  fun fail(msg: String)
+
+  fun complete(success: Bool)
 
 class ref PropertyHelper
   """
@@ -27,10 +22,10 @@ class ref PropertyHelper
   """
   let _params: PropertyParams
   let _params_fmt: String
-  let _th: _TestLogger
+  let _th: PropertyResultNotify
   var _did_fail: Bool = false
 
-  new ref create(params: PropertyParams, h: _TestLogger) =>
+  new ref create(params: PropertyParams, h: PropertyResultNotify) =>
     _params = params
     _params_fmt = _format_params(params)
     _th = h

--- a/ponycheck/property_runner.pony
+++ b/ponycheck/property_runner.pony
@@ -1,0 +1,128 @@
+
+actor PropertyRunner[T]
+  """
+  Actor executing a Property1 implementation
+  in a way that allows garbage collection between single
+  property executions, because it uses recursive behaviours
+  for looping.
+  """
+  let _prop1: Property1[T]
+  let _params: PropertyParams
+  let _rnd: Randomness
+  let _notify: PropertyResultNotify
+  let _ph: PropertyHelper
+  let _gen: Generator[T]
+  var _shrinker: Iterator[T^] = _EmptyIterator[T^]
+
+  new create(
+    p1: Property1[T] iso,
+    params: PropertyParams,
+    notify: PropertyResultNotify
+  ) =>
+    _prop1 = consume p1
+    _params = params
+    _notify = notify
+    _ph = PropertyHelper(_params, _notify)
+    _rnd = Randomness(_params.seed)
+    _gen = _prop1.gen()
+
+  be run(n: USize = 0) =>
+    if n == _params.num_samples then
+      complete() // all samples have been successful
+      return
+    end
+    (var sample, _shrinker) = _gen.generate_and_shrink(_rnd)
+    // create a string representation before consuming ``sample`` with property
+    (sample, let sample_repr) = _Stringify[T](consume sample)
+    try
+      _prop1.property(consume sample, _ph)?
+    else
+      fail(sample_repr, 0 where err=true)
+      return
+    end
+    if _ph.failed() then
+      // found a bad example, try to shrink it
+      if not _shrinker.has_next() then
+        _ph.log("no shrinks available")
+        fail(sample_repr, 0)
+      else
+        do_shrink(sample_repr)
+      end
+    else
+      // property holds, recurse
+      run(n + 1)
+    end
+
+  be do_shrink(repr: String, rounds: USize = 0) =>
+    // shrink iters can be infinite, so we need to limit
+    // the examples we consider during shrinking
+    if rounds == _params.max_shrink_rounds then
+      fail(repr, rounds)
+      return
+    end
+
+    (let shrink, let shrink_repr) =
+      try
+        _Stringify[T](_shrinker.next()?)
+      else
+        // no more shrink samples, report previous failed example
+        fail(repr, rounds)
+        return
+      end
+
+    _ph.reset()
+
+    try
+      _prop1.property(consume shrink, _ph)?
+    else
+      fail(shrink_repr, rounds where err=true)
+      return
+    end
+
+    if not _ph.failed() then
+      // we have a sample that did not fail and thus can stop shrinking
+      //_ph.log("shrink: " + shrink_repr + " did not fail")
+      fail(repr, rounds)
+    else
+      // we have a failing shrink sample, recurse
+      //_ph.log("shrink: " + shrink_repr + " did fail")
+      do_shrink(shrink_repr, rounds + 1)
+    end
+  
+  fun ref complete() =>
+    """
+    complete the Property execution
+    """
+    _notify.complete(not _ph.failed())
+
+  fun ref fail(repr: String, rounds: USize = 0, err: Bool = false) =>
+    """
+    complete the Property execution 
+    while signalling failure to the notify
+    """
+    if err then
+      _ph.report_error(repr, rounds)
+    else
+      _ph.report_failed(repr, rounds)
+    end
+    _notify.complete(false)
+
+
+class _EmptyIterator[T]
+  fun ref has_next(): Bool => false
+  fun ref next(): T^ ? => error
+
+primitive _Stringify[T]
+  fun apply(t: T): (T^, String) =>
+    """turn anything into a string"""
+    let digest = (digestof t)
+    let s =
+      iftype T <: Stringable #read then
+        t.string()
+      elseif T <: ReadSeq[Stringable] #read then
+        "[" + " ".join(t.values()) + "]"
+      else
+        "<identity:" + digest.string() + ">"
+      end
+    (consume t, consume s)
+

--- a/ponycheck/property_unit_test.pony
+++ b/ponycheck/property_unit_test.pony
@@ -1,0 +1,26 @@
+use "ponytest"
+
+class iso Property1UnitTest[T] is UnitTest
+  var _prop1: ( Property1[T] iso | None )
+  let _name: String
+
+  new iso create(p1: Property1[T] iso, name': (String | None) = None) =>
+    _name =
+      match name'
+      | None => p1.name()
+      | let s: String => s
+      end
+    _prop1 = consume p1
+
+
+  fun name(): String => _name
+
+  fun ref apply(h: TestHelper) ? =>
+    let prop = ((_prop1 = None) as Property1[T] iso^)
+    let params = prop.params()
+    h.long_test(params.timeout)
+    PropertyRunner[T](
+      consume prop,
+      params,
+      h
+    ).run()

--- a/ponycheck/test/asunitest.pony
+++ b/ponycheck/test/asunitest.pony
@@ -1,28 +1,71 @@
 use "ponytest"
 use ".."
 
-class PropertyAsUnitTest is Property1[U8]
+class SuccessfulProperty is Property1[U8]
   """
   this just tests that a property is compatible with ponytest
   """
-  fun name(): String => "property1/asUnitTest"
+  fun name(): String => "as_unit_test/successful/property"
 
   fun gen(): Generator[U8] => Generators.u8(0, 10)
 
   fun property(arg1: U8, h: PropertyHelper) =>
     h.assert_true(arg1 <= U8(10))
 
-// TODO: test for failing Properties using a separate PonyTest invocation
-class FailingPropertyAsUnitTest is Property1[U8]
-  fun name(): String => "(fail) property1/asFailingUnitTest"
+class val UnitTestPropertyNotify is PropertyResultNotify
+  let _th: TestHelper
+  let _should_succeed: Bool
+
+  new val create(th: TestHelper, should_succeed: Bool = true) =>
+    _should_succeed = should_succeed
+    _th = th
+
+  fun log(msg: String, verbose: Bool) =>
+    _th.log(msg, verbose)
+
+  fun fail(msg: String) =>
+    _th.log("FAIL: " + msg)
+
+  fun complete(success: Bool) =>
+    _th.log("COMPLETE: " + success.string())
+    let result = (success and _should_succeed) or ((not success) and (not _should_succeed))
+    _th.complete(result)
+
+class SuccessfulPropertyTest is UnitTest
+
+  fun name(): String => "as_unit_test/successful"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(20_000_000_000)
+    let property = recover iso SuccessfulProperty end
+    let property_notify = UnitTestPropertyNotify(h, true)
+    let params = property.params()
+    let runner = PropertyRunner[U8](consume property, params, property_notify)
+    runner.run()
+
+
+class FailingProperty is Property1[U8]
+  fun name(): String => "as_unit_test/failing/property"
 
   fun gen(): Generator[U8] => Generators.u8(0, 10)
 
   fun property(arg1: U8, h: PropertyHelper) =>
     h.assert_true(arg1 <= U8(5))
 
-class ErroringPropertyAsUnitTest is Property1[U8]
-  fun name(): String => "(fail) property/asErroringUnitTest"
+class FailingPropertyTest is UnitTest
+  fun name(): String => "as_unit_test/failing"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(20_000_000_000)
+    let property = recover iso FailingProperty end
+    let property_notify = UnitTestPropertyNotify(h, false)
+    let params = property.params()
+    let runner = PropertyRunner[U8](consume property, params, property_notify)
+    runner.run()
+
+
+class ErroringProperty is Property1[U8]
+  fun name(): String => "as_unit_test/erroring/property"
 
   fun gen(): Generator[U8] => Generators.u8(0, 1)
 
@@ -30,3 +73,16 @@ class ErroringPropertyAsUnitTest is Property1[U8]
     if arg1 < 2 then
       error
     end
+
+class ErroringPropertyTest is UnitTest
+  fun name(): String => "as_unit_test/erroring"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(20_000_000_000)
+    let property = recover iso ErroringProperty end
+    let property_notify = UnitTestPropertyNotify(h, false)
+    let params = property.params()
+    let runner = PropertyRunner[U8](consume property, params, property_notify)
+    runner.run()
+
+

--- a/ponycheck/test/forall.pony
+++ b/ponycheck/test/forall.pony
@@ -2,18 +2,18 @@ use "ponytest"
 use ".."
 
 class ForAllTest is UnitTest
-  fun name(): String => "ponycheck/forall"
+  fun name(): String => "ponycheck/for_all"
 
   fun apply(h: TestHelper) =>
-    Ponycheck.forAll[U8](recover Generators.unit[U8](0) end, h)(
+    Ponycheck.for_all[U8](recover Generators.unit[U8](0) end, h)(
       {(u, h) => h.assert_eq[U8](u, 0, u.string() + " == 0") })
 
 class MultipleForAllTest is UnitTest
-  fun name(): String => "ponycheck/multipleForAll"
+  fun name(): String => "ponycheck/multiple_for_all"
 
   fun apply(h: TestHelper) =>
-    Ponycheck.forAll[U8](recover Generators.unit[U8](0) end, h)(
+    Ponycheck.for_all[U8](recover Generators.unit[U8](0) end, h)(
       {(u, h) => h.assert_eq[U8](u, 0, u.string() + " == 0") })
 
-    Ponycheck.forAll[U8](recover Generators.unit[U8](1) end, h)(
+    Ponycheck.for_all[U8](recover Generators.unit[U8](1) end, h)(
       {(u, h) => h.assert_eq[U8](u, 1, u.string() + " == 1") })

--- a/ponycheck/test/forall.pony
+++ b/ponycheck/test/forall.pony
@@ -4,16 +4,16 @@ use ".."
 class ForAllTest is UnitTest
   fun name(): String => "ponycheck/for_all"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     Ponycheck.for_all[U8](recover Generators.unit[U8](0) end, h)(
-      {(u, h) => h.assert_eq[U8](u, 0, u.string() + " == 0") })
+      {(u, h) => h.assert_eq[U8](u, 0, u.string() + " == 0") })?
 
 class MultipleForAllTest is UnitTest
   fun name(): String => "ponycheck/multiple_for_all"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     Ponycheck.for_all[U8](recover Generators.unit[U8](0) end, h)(
-      {(u, h) => h.assert_eq[U8](u, 0, u.string() + " == 0") })
+      {(u, h) => h.assert_eq[U8](u, 0, u.string() + " == 0") })?
 
     Ponycheck.for_all[U8](recover Generators.unit[U8](1) end, h)(
-      {(u, h) => h.assert_eq[U8](u, 1, u.string() + " == 1") })
+      {(u, h) => h.assert_eq[U8](u, 1, u.string() + " == 1") })?

--- a/ponycheck/test/main.pony
+++ b/ponycheck/test/main.pony
@@ -1,4 +1,5 @@
 use "ponytest"
+use ".."
 
 actor Main is TestList
   new create(env: Env) => PonyTest(env, this)
@@ -20,9 +21,10 @@ actor Main is TestList
     test(MapIsOfEmptyTest)
     test(MapIsOfMaxTest)
     test(MapIsOfIdentityTest)
-    test(PropertyAsUnitTest.unit_test())
-    test(FailingPropertyAsUnitTest.unit_test())
-    test(ErroringPropertyAsUnitTest.unit_test())
+    test(SuccessfulPropertyTest)
+    test(Property1UnitTest[U8](SuccessfulProperty))
+    test(FailingPropertyTest)
+    test(ErroringPropertyTest)
     test(ForAllTest)
     test(MultipleForAllTest)
     test(ASCIIRangeTest)

--- a/ponycheck/test/main.pony
+++ b/ponycheck/test/main.pony
@@ -34,3 +34,4 @@ actor Main is TestList
     test(UnicodeStringShrinkTest)
     test(MinUnicodeStringShrinkTest)
     test(FilterMapShrinkTest)
+    test(RunnerInfiniteShrinkTest)

--- a/ponycheck/test/runner.pony
+++ b/ponycheck/test/runner.pony
@@ -1,0 +1,48 @@
+use ".."
+use "itertools"
+use "ponytest"
+
+class InfiniteShrinkProperty is Property1[String]
+
+  fun name(): String => "property_runner/inifinite_shrink/property"
+
+  fun gen(): Generator[String] =>
+    Generator[String](
+      object is GenObj[String]
+        fun generate(r: Randomness): String^ =>
+          "decided by fair dice roll, totally random"
+        
+        fun shrink(t: String): ValueAndShrink[String] =>
+          (t, Iter[String^].repeat_value(t))
+      end)
+
+  fun property(arg1: String, ph: PropertyHelper) =>
+    ph.assert_true(arg1.size() >  100) // assume this failing
+
+
+class iso RunnerInfiniteShrinkTest is UnitTest
+  """
+  ensure that having a failing property with an infinite generator
+  is not shrinking infinitely
+  """
+  fun name(): String => "property_runner/infinite_shrink"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(20_000_000_000)
+    let property = InfiniteShrinkProperty
+    let property_notify =
+      object val is PropertyResultNotify
+        fun log(msg: String, verbose: Bool) =>
+          h.log(msg, verbose)
+        fun fail(msg: String) =>
+          h.log("FAIL: " + msg)
+          h.complete(true)
+        fun complete(success: Bool) =>
+          h.log("COMPLETE: " + success.string())
+          h.complete(not success)
+      end
+    let runner = PropertyRunner[String](
+      recover InfiniteShrinkProperty end,
+      property_notify)
+    runner.run()
+

--- a/ponycheck/test/runner.pony
+++ b/ponycheck/test/runner.pony
@@ -29,7 +29,6 @@ class iso RunnerInfiniteShrinkTest is UnitTest
 
   fun apply(h: TestHelper) =>
     h.long_test(20_000_000_000)
-    let property = InfiniteShrinkProperty
     let property_notify =
       object val is PropertyResultNotify
         fun log(msg: String, verbose: Bool) =>
@@ -41,8 +40,12 @@ class iso RunnerInfiniteShrinkTest is UnitTest
           h.log("COMPLETE: " + success.string())
           h.complete(not success)
       end
+    let property = recover iso InfiniteShrinkProperty end
+    let params = property.params()
+
     let runner = PropertyRunner[String](
-      recover InfiniteShrinkProperty end,
+      consume property,
+      params,
       property_notify)
     runner.run()
 


### PR DESCRIPTION
in order to ease testing ponytest integration

* require `Property1[T]` to have an `iso` reference capability in order to run with PropertyRunner
* rename `Ponycheck.forAll` to `Ponycheck.for_all` and made `apply` call on it partial
* ensure we do not shrink infinitely if we get an infinite shrinking iter
* change ponytest integration API (this is to ensure that `Property1[T]` can be `iso`):

  ```pony
  //before
  test(MyProperty.unit_test())
  ```
  ```pony
  // after
  test(Property1UnitTest[String](MyProperty))
  ```
* Created `PropertyResultNotify` as interface for integration with any code that executes Properties using the `PropertyRunner`, which was renamed from `_Runner` in order to make it publicly available for any framework that might wants to use it.