### PR TITLE
fix reporting for a failed sample after shrinking

### DIFF
--- a/ponycheck/test/main.pony
+++ b/ponycheck/test/main.pony
@@ -38,6 +38,7 @@ actor Main is TestList
     test(MinUnicodeStringShrinkTest)
     test(FilterMapShrinkTest)
     test(RunnerInfiniteShrinkTest)
+    test(RunnerReportFailedSampleTest)
     test(RunnerAsyncPropertyCompleteTest)
     test(RunnerAsyncPropertyCompleteFalseTest)
     test(RunnerAsyncFailTest)
@@ -46,3 +47,4 @@ actor Main is TestList
     test(RunnerAsyncCompleteMultiSucceedActionTest)
     test(RunnerAsyncMultiCompleteSucceedTest)
     test(RunnerAsyncMultiCompleteFailTest)
+


### PR DESCRIPTION
when a sample has been found that was satisfied the property,
previously the satisfying sample was logged to the user.

fixes #36 