### PR TITLE
properly stringify int-property samples

### DIFF
--- a/ponycheck/_test.pony
+++ b/ponycheck/_test.pony
@@ -1,0 +1,23 @@
+use "ponytest"
+
+primitive PrivateTests is TestList
+  fun tag tests(test: PonyTest) =>
+    test(_StringifyTest)
+
+class iso _StringifyTest is UnitTest
+
+  fun name(): String => "stringify"
+
+  fun apply(h: TestHelper) =>
+    (let _, var s) = _Stringify.apply[(U8, U8)]((0, 1))
+    h.assert_eq[String](s, "(0, 1)")
+    (let _, s) = _Stringify.apply[(U8, U32, U128)]((0, 1, 2))
+    h.assert_eq[String](s, "(0, 1, 2)")
+    (let _, s) = _Stringify.apply[(U8, (U32, U128))]((0, (1, 2)))
+    h.assert_eq[String](s, "(0, (1, 2))")
+    (let _, s) = _Stringify.apply[((U8, U32), U128)](((0, 1), 2))
+    h.assert_eq[String](s, "((0, 1), 2)")
+    let a: Array[U8] = [ U8(0); U8(42) ]
+    (let _, s) = _Stringify.apply[Array[U8]](a)
+    h.assert_eq[String](s, "[0 42]")
+

--- a/ponycheck/int_properties.pony
+++ b/ponycheck/int_properties.pony
@@ -92,14 +92,7 @@ class IntPairPropertySample is Stringable
   fun string(): String iso^ =>
     let num1: String val = _StringifyIntArg(choice, int1)
     let num2: String val = _StringifyIntArg(choice, int2)
-      recover iso
-        String()
-          .>append("(")
-          .>append(num1)
-          .>append(", ")
-          .>append(num2)
-          .>append(")")
-      end
+    "".join(["("; num1; ", "; num2; ")"].values())
 
 
 type IntPairUnitTest is Property1UnitTest[IntPairPropertySample]

--- a/ponycheck/int_properties.pony
+++ b/ponycheck/int_properties.pony
@@ -1,6 +1,42 @@
-type IntUnitTest is Property1UnitTest[(U8, U128)]
+class IntPropertySample is Stringable
+  let choice: U8
+  let int: U128
 
-trait IntProperty is Property1[(U8, U128)]
+  new create(choice': U8, int': U128) =>
+    choice = choice'
+    int = int'
+
+  fun string(): String iso^ =>
+    let prefix =
+      match choice % 14
+      | 0 => "U8"
+      | 1 => "U16"
+      | 2 => "U32"
+      | 3 => "U64"
+      | 4 => "ULong"
+      | 5 => "USize"
+      | 6 => "U128"
+      | 7 => "I8"
+      | 8 => "I16"
+      | 9 => "I32"
+      | 10 => "I64"
+      | 11 => "ILong"
+      | 12 => "ISize"
+      | 13 => "I128"
+      else
+        ""
+      end
+      recover iso
+        String()
+          .>append(prefix)
+          .>append("(")
+          .>append(int.string())
+          .>append(")")
+      end
+
+type IntUnitTest is Property1UnitTest[IntPropertySample]
+
+trait IntProperty is Property1[IntPropertySample]
   """
   A property implementation for conveniently evaluating properties
   for all Pony Integer types at once.
@@ -15,15 +51,15 @@ trait IntProperty is Property1[(U8, U128)]
       h.assert_eq[T](T.from[U8](0), x / T.from[U8](0))
   ```
   """
-  fun gen(): Generator[(U8, U128)] =>
-    Generators.zip2[U8, U128](
+  fun gen(): Generator[IntPropertySample] =>
+    Generators.map2[U8, U128, IntPropertySample](
       Generators.u8(),
-      Generators.u128())
+      Generators.u128(),
+      {(choice, int) => IntPropertySample(choice, int) })
 
-  fun ref property(sample: (U8, U128), h: PropertyHelper) ? =>
-    let t: U8 = sample._1
-    let x = sample._2
-    match t % 14
+  fun ref property(sample: IntPropertySample, h: PropertyHelper) ? =>
+    let x = sample.int
+    match sample.choice % 14
     | 0 => int_property[U8](x.u8(), h)?
     | 1 => int_property[U16](x.u16(), h)?
     | 2 => int_property[U32](x.u32(), h)?
@@ -38,13 +74,60 @@ trait IntProperty is Property1[(U8, U128)]
     | 11 => int_property[ILong](x.ilong(), h)?
     | 12 => int_property[ISize](x.isize(), h)?
     | 13 => int_property[I128](x.i128(), h)?
+    else
+      h.log("rem is broken")
+      error
     end
 
   fun ref int_property[T: (Int & Integer[T] val)](x: T, h: PropertyHelper)?
 
-type IntPairUnitTest is Property1UnitTest[(U8, (U128, U128))]
+class IntPairPropertySample is Stringable
+  let choice: U8
+  let int1: U128
+  let int2: U128
 
-trait IntPairProperty is Property1[(U8, (U128, U128))]
+  new create(choice': U8, int1': U128, int2': U128) =>
+    choice = choice'
+    int1 = int1'
+    int2 = int2'
+
+  fun string(): String iso^ =>
+    let prefix =
+      match choice % 14
+      | 0 => "U8"
+      | 1 => "U16"
+      | 2 => "U32"
+      | 3 => "U64"
+      | 4 => "ULong"
+      | 5 => "USize"
+      | 6 => "U128"
+      | 7 => "I8"
+      | 8 => "I16"
+      | 9 => "I32"
+      | 10 => "I64"
+      | 11 => "ILong"
+      | 12 => "ISize"
+      | 13 => "I128"
+      else
+        ""
+      end
+      recover iso
+        String()
+          .>append("(")
+          .>append(prefix)
+          .>append("(")
+          .>append(int1.string())
+          .>append("), ")
+          .>append(prefix)
+          .>append("(")
+          .>append(int2.string())
+          .>append("))")
+      end
+
+
+type IntPairUnitTest is Property1UnitTest[IntPairPropertySample]
+
+trait IntPairProperty is Property1[IntPairPropertySample]
   """
   A property implementation for conveniently evaluating properties
   for pairs of integers of all Pony integer types at once.
@@ -59,19 +142,17 @@ trait IntPairProperty is Property1[(U8, (U128, U128))]
       h.assert_eq[T](x * y, y * x)
   ```
   """
-  fun gen(): Generator[(U8, (U128, U128))] =>
-    Generators.zip2[U8, (U128, U128)](
+  fun gen(): Generator[IntPairPropertySample] =>
+    Generators.map3[U8, U128, U128, IntPairPropertySample](
       Generators.u8(),
-      Generators.zip2[U128, U128](
-        Generators.u128(),
-        Generators.u128()
-      ))
+      Generators.u128(),
+      Generators.u128(),
+      {(choice, int1, int2) => IntPairPropertySample(choice, int1, int2) })
 
-  fun ref property(sample: (U8, (U128, U128)), h: PropertyHelper) ? =>
-    let t: U8 = sample._1
-    let x = sample._2._1
-    let y = sample._2._2
-    match t % 14
+  fun ref property(sample: IntPairPropertySample, h: PropertyHelper) ? =>
+    let x = sample.int1
+    let y = sample.int2
+    match sample.choice % 14
     | 0 => int_property[U8](x.u8(), y.u8(), h)?
     | 1 => int_property[U16](x.u16(), y.u16(), h)?
     | 2 => int_property[U32](x.u32(), y.u32(), h)?
@@ -86,6 +167,9 @@ trait IntPairProperty is Property1[(U8, (U128, U128))]
     | 11 => int_property[ILong](x.ilong(), y.ilong(), h)?
     | 12 => int_property[ISize](x.isize(), y.isize(), h)?
     | 13 => int_property[I128](x.i128(), y.i128(), h)?
+    else
+      h.log("rem is broken")
+      error
     end
 
   fun ref int_property[T: (Int & Integer[T] val)](x: T, y: T, h: PropertyHelper)?

--- a/ponycheck/int_properties.pony
+++ b/ponycheck/int_properties.pony
@@ -1,3 +1,26 @@
+primitive _StringifyIntArg
+  fun apply(choice: U8, int: U128): String iso ^ =>
+   let num =
+     match choice % 14
+     | 0 => "U8(" + int.u8().string() + ")"
+     | 1 => "U16(" + int.u16().string() + ")"
+     | 2 => "U32(" + int.u32().string() + ")"
+     | 3 => "U64(" + int.u64().string() + ")"
+     | 4 => "ULong(" + int.ulong().string() + ")"
+     | 5 => "USize(" + int.usize().string() + ")"
+     | 6 => "U128(" + int.string() + ")"
+     | 7 => "I8(" + int.i8().string() + ")"
+     | 8 => "I16(" + int.i16().string() + ")"
+     | 9 => "I32(" + int.i32().string() + ")"
+     | 10 => "I64(" + int.i64().string() + ")"
+     | 11 => "ILong(" + int.ilong().string() + ")"
+     | 12 => "ISize(" + int.isize().string() + ")"
+     | 13 => "I128(" + int.i128().string() + ")"
+     else
+       ""
+     end
+   num.clone()
+
 class IntPropertySample is Stringable
   let choice: U8
   let int: U128
@@ -7,32 +30,7 @@ class IntPropertySample is Stringable
     int = int'
 
   fun string(): String iso^ =>
-    let prefix =
-      match choice % 14
-      | 0 => "U8"
-      | 1 => "U16"
-      | 2 => "U32"
-      | 3 => "U64"
-      | 4 => "ULong"
-      | 5 => "USize"
-      | 6 => "U128"
-      | 7 => "I8"
-      | 8 => "I16"
-      | 9 => "I32"
-      | 10 => "I64"
-      | 11 => "ILong"
-      | 12 => "ISize"
-      | 13 => "I128"
-      else
-        ""
-      end
-      recover iso
-        String()
-          .>append(prefix)
-          .>append("(")
-          .>append(int.string())
-          .>append(")")
-      end
+    _StringifyIntArg(choice, int)
 
 type IntUnitTest is Property1UnitTest[IntPropertySample]
 
@@ -92,36 +90,15 @@ class IntPairPropertySample is Stringable
     int2 = int2'
 
   fun string(): String iso^ =>
-    let prefix =
-      match choice % 14
-      | 0 => "U8"
-      | 1 => "U16"
-      | 2 => "U32"
-      | 3 => "U64"
-      | 4 => "ULong"
-      | 5 => "USize"
-      | 6 => "U128"
-      | 7 => "I8"
-      | 8 => "I16"
-      | 9 => "I32"
-      | 10 => "I64"
-      | 11 => "ILong"
-      | 12 => "ISize"
-      | 13 => "I128"
-      else
-        ""
-      end
+    let num1: String val = _StringifyIntArg(choice, int1)
+    let num2: String val = _StringifyIntArg(choice, int2)
       recover iso
         String()
           .>append("(")
-          .>append(prefix)
-          .>append("(")
-          .>append(int1.string())
-          .>append("), ")
-          .>append(prefix)
-          .>append("(")
-          .>append(int2.string())
-          .>append("))")
+          .>append(num1)
+          .>append(", ")
+          .>append(num2)
+          .>append(")")
       end
 
 

--- a/ponycheck/property_runner.pony
+++ b/ponycheck/property_runner.pony
@@ -335,7 +335,17 @@ primitive _Stringify
       | (let s1: Stringable, let s2: Stringable) =>
         "(" + s1.string() + ", " + s2.string() + ")"
       | (let s1: Stringable, let s2: ReadSeq[Stringable]) =>
-        "(" + s1.string() + ", " + "[" + " ".join(s2.values()) + "]" + ")"
+        "(" + s1.string() + ", [" + " ".join(s2.values()) + "])"
+      | (let s1: ReadSeq[Stringable], let s2: Stringable) =>
+        "([" + " ".join(s1.values()) + "], " + s2.string() + ")"
+      | (let s1: ReadSeq[Stringable], let s2: ReadSeq[Stringable]) =>
+        "([" + " ".join(s1.values()) + "], [" + " ".join(s2.values()) + "])"
+      | (let s1: Stringable, let s2: Stringable, let s3: Stringable) =>
+        "(" + s1.string() + ", " + s2.string() + ", " + s3.string() + ")"
+      | ((let s1: Stringable, let s2: Stringable), let s3: Stringable) =>
+        "((" + s1.string() + ", " + s2.string() + "), " + s3.string() + ")"
+      | (let s1: Stringable, (let s2: Stringable, let s3: Stringable)) =>
+        "(" + s1.string() + ", (" + s2.string() + ", " + s3.string() + "))"
       else
         "<identity:" + digest.string() + ">"
       end

--- a/ponycheck/test/ints.pony
+++ b/ponycheck/test/ints.pony
@@ -24,7 +24,7 @@ class SuccessfulIntPropertyTest is UnitTest
     let property_logger = UnitTestPropertyLogger(h)
     let params = property.params()
     h.long_test(params.timeout)
-    let runner = PropertyRunner[(U8, U128)](
+    let runner = PropertyRunner[IntPropertySample](
       consume property,
       params,
       property_notify,
@@ -47,7 +47,7 @@ class SuccessfulIntPairPropertyTest is UnitTest
     let property_logger = UnitTestPropertyLogger(h)
     let params = property.params()
     h.long_test(params.timeout)
-    let runner = PropertyRunner[(U8, (U128, U128))](
+    let runner = PropertyRunner[IntPairPropertySample](
       consume property,
       params,
       property_notify,

--- a/ponycheck/test/main.pony
+++ b/ponycheck/test/main.pony
@@ -26,6 +26,8 @@ actor Main is TestList
     test(MapIsOfMaxTest)
     test(MapIsOfIdentityTest)
 
+    PrivateTests.tests(test)
+
     AsUnitTestTests.tests(test)
 
     ForAllTests.tests(test)


### PR DESCRIPTION
and extend support for turning samples into strings to more tuple types.

Previously it was not evident for which sample an IntProperty or IntPairProperty was failing as its samples (tuples) have not been stringified properly (e.g. as `<identity:3>`).

E.g.: https://circleci.com/gh/mfelsche/stdlib-properties/45