### PR TITLE
Fix Randomness.u64() returning numbers out of the given range

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,3 +1,3 @@
-## Fix Randomnes.u64() returning numbers out of the given range
+## Fix Randomness.u64() returning numbers out of the given range
 
-When the range was specified, Randomnes.u64() could return random numbers outside of it.
+When the range was specified, Randomness.u64() could return random numbers outside of it.

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,3 @@
+## Fix Randomnes.u64() returning numbers out of the given range
+
+When the range was specified, Randomnes.u64() could return random numbers outside of it.

--- a/ponycheck/_test.pony
+++ b/ponycheck/_test.pony
@@ -1410,7 +1410,7 @@ class iso _RandomnessProperty[A: Comparable[A] #read, R: _RandomCase[A] val] is 
     let max = R.generator()
     Generators.zip2[A, A](min, max)
       .filter(
-        { (pair) => (pair, (pair._1 < pair._2)) }
+        { (pair) => (pair, (pair._1 <= pair._2)) }
       )
 
   fun property(arg1: (A, A), ph: PropertyHelper) =>

--- a/ponycheck/_test.pony
+++ b/ponycheck/_test.pony
@@ -77,18 +77,18 @@ actor Main is TestList
     test(_SuccessfulIntPairPropertyTest)
     test(IntPairUnitTest(_SuccessfulIntPairProperty))
 
-    test(Property1UnitTest[(U8, U8)](_RandomnessProperty[U8, RndCaseU8]("U8")))
-    test(Property1UnitTest[(I8, I8)](_RandomnessProperty[I8, RndCaseI8]("I8")))
-    test(Property1UnitTest[(U16, U16)](_RandomnessProperty[U16, RndCaseU16]("U16")))
-    test(Property1UnitTest[(I16, I16)](_RandomnessProperty[I16, RndCaseI16]("I16")))
-    test(Property1UnitTest[(U32, U32)](_RandomnessProperty[U32, RndCaseU32]("U32")))
-    test(Property1UnitTest[(I32, I32)](_RandomnessProperty[I32, RndCaseI32]("I32")))
-    test(Property1UnitTest[(U64, U64)](_RandomnessProperty[U64, RndCaseU64]("U64")))
-    test(Property1UnitTest[(I64, I64)](_RandomnessProperty[I64, RndCaseI64]("I64")))
-    test(Property1UnitTest[(U128, U128)](_RandomnessProperty[U128, RndCaseU128]("U128")))
-    test(Property1UnitTest[(I128, I128)](_RandomnessProperty[I128, RndCaseI128]("I128")))
-    test(Property1UnitTest[(ISize, ISize)](_RandomnessProperty[ISize, RndCaseISize]("ISize")))
-    test(Property1UnitTest[(ILong, ILong)](_RandomnessProperty[ILong, RndCaseILong]("ILong")))
+    test(Property1UnitTest[(U8, U8)](_RandomnessProperty[U8, _RandomCaseU8]("U8")))
+    test(Property1UnitTest[(I8, I8)](_RandomnessProperty[I8, _RandomCaseI8]("I8")))
+    test(Property1UnitTest[(U16, U16)](_RandomnessProperty[U16, _RandomCaseU16]("U16")))
+    test(Property1UnitTest[(I16, I16)](_RandomnessProperty[I16, _RandomCaseI16]("I16")))
+    test(Property1UnitTest[(U32, U32)](_RandomnessProperty[U32, _RandomCaseU32]("U32")))
+    test(Property1UnitTest[(I32, I32)](_RandomnessProperty[I32, _RandomCaseI32]("I32")))
+    test(Property1UnitTest[(U64, U64)](_RandomnessProperty[U64, _RandomCaseU64]("U64")))
+    test(Property1UnitTest[(I64, I64)](_RandomnessProperty[I64, _RandomCaseI64]("I64")))
+    test(Property1UnitTest[(U128, U128)](_RandomnessProperty[U128, _RandomCaseU128]("U128")))
+    test(Property1UnitTest[(I128, I128)](_RandomnessProperty[I128, _RandomCaseI128]("I128")))
+    test(Property1UnitTest[(ISize, ISize)](_RandomnessProperty[ISize, _RandomCaseISize]("ISize")))
+    test(Property1UnitTest[(ILong, ILong)](_RandomnessProperty[ILong, _RandomCaseILong]("ILong")))
 
 
 class iso _StringifyTest is UnitTest
@@ -1291,14 +1291,14 @@ class iso _AsyncProperty is Property1[String]
   fun ref property(arg1: String, ph: PropertyHelper) =>
     _AsyncDelayingActor(ph, _action).do_it()
 
-interface val RndCase[A: Comparable[A] #read]
+interface val _RandomCase[A: Comparable[A] #read]
   new val create()
 
   fun test(min: A, max: A): A
 
   fun generator(): Generator[A]
 
-primitive RndCaseU8 is RndCase[U8]
+primitive _RandomCaseU8 is _RandomCase[U8]
   fun test(min: U8, max: U8): U8 =>
     let rnd = Randomness(Time.millis())
     rnd.u8(min, max)
@@ -1306,7 +1306,7 @@ primitive RndCaseU8 is RndCase[U8]
   fun generator(): Generator[U8] =>
     Generators.u8()
 
-primitive RndCaseU16 is RndCase[U16]
+primitive _RandomCaseU16 is _RandomCase[U16]
   fun test(min: U16, max: U16): U16 =>
     let rnd = Randomness(Time.millis())
     rnd.u16(min, max)
@@ -1314,7 +1314,7 @@ primitive RndCaseU16 is RndCase[U16]
   fun generator(): Generator[U16] =>
     Generators.u16()
 
-primitive RndCaseU32 is RndCase[U32]
+primitive _RandomCaseU32 is _RandomCase[U32]
   fun test(min: U32, max: U32): U32 =>
     let rnd = Randomness(Time.millis())
     rnd.u32(min, max)
@@ -1322,7 +1322,7 @@ primitive RndCaseU32 is RndCase[U32]
   fun generator(): Generator[U32] =>
     Generators.u32()
 
-primitive RndCaseU64 is RndCase[U64]
+primitive _RandomCaseU64 is _RandomCase[U64]
   fun test(min: U64, max: U64): U64 =>
     let rnd = Randomness(Time.millis())
     rnd.u64(min, max)
@@ -1330,7 +1330,7 @@ primitive RndCaseU64 is RndCase[U64]
   fun generator(): Generator[U64] =>
     Generators.u64()
 
-primitive RndCaseU128 is RndCase[U128]
+primitive _RandomCaseU128 is _RandomCase[U128]
   fun test(min: U128, max: U128): U128 =>
     let rnd = Randomness(Time.millis())
     rnd.u128(min, max)
@@ -1338,7 +1338,7 @@ primitive RndCaseU128 is RndCase[U128]
   fun generator(): Generator[U128] =>
     Generators.u128()
 
-primitive RndCaseI8 is RndCase[I8]
+primitive _RandomCaseI8 is _RandomCase[I8]
   fun test(min: I8, max: I8): I8 =>
     let rnd = Randomness(Time.millis())
     rnd.i8(min, max)
@@ -1346,7 +1346,7 @@ primitive RndCaseI8 is RndCase[I8]
   fun generator(): Generator[I8] =>
     Generators.i8()
 
-primitive RndCaseI16 is RndCase[I16]
+primitive _RandomCaseI16 is _RandomCase[I16]
   fun test(min: I16, max: I16): I16 =>
     let rnd = Randomness(Time.millis())
     rnd.i16(min, max)
@@ -1354,7 +1354,7 @@ primitive RndCaseI16 is RndCase[I16]
   fun generator(): Generator[I16] =>
     Generators.i16()
 
-primitive RndCaseI32 is RndCase[I32]
+primitive _RandomCaseI32 is _RandomCase[I32]
   fun test(min: I32, max: I32): I32 =>
     let rnd = Randomness(Time.millis())
     rnd.i32(min, max)
@@ -1362,7 +1362,7 @@ primitive RndCaseI32 is RndCase[I32]
   fun generator(): Generator[I32] =>
     Generators.i32()
 
-primitive RndCaseI64 is RndCase[I64]
+primitive _RandomCaseI64 is _RandomCase[I64]
   fun test(min: I64, max: I64): I64 =>
     let rnd = Randomness(Time.millis())
     rnd.i64(min, max)
@@ -1370,7 +1370,7 @@ primitive RndCaseI64 is RndCase[I64]
   fun generator(): Generator[I64] =>
     Generators.i64()
 
-primitive RndCaseI128 is RndCase[I128]
+primitive _RandomCaseI128 is _RandomCase[I128]
   fun test(min: I128, max: I128): I128 =>
     let rnd = Randomness(Time.millis())
     rnd.i128(min, max)
@@ -1378,7 +1378,7 @@ primitive RndCaseI128 is RndCase[I128]
   fun generator(): Generator[I128] =>
     Generators.i128()
 
-primitive RndCaseISize is RndCase[ISize]
+primitive _RandomCaseISize is _RandomCase[ISize]
   fun test(min: ISize, max: ISize): ISize =>
     let rnd = Randomness(Time.millis())
     rnd.isize(min, max)
@@ -1386,7 +1386,7 @@ primitive RndCaseISize is RndCase[ISize]
   fun generator(): Generator[ISize] =>
     Generators.isize()
 
-primitive RndCaseILong is RndCase[ILong]
+primitive _RandomCaseILong is _RandomCase[ILong]
   fun test(min: ILong, max: ILong): ILong =>
     let rnd = Randomness(Time.millis())
     rnd.ilong(min, max)
@@ -1394,7 +1394,7 @@ primitive RndCaseILong is RndCase[ILong]
   fun generator(): Generator[ILong] =>
     Generators.ilong()
 
-class iso _RandomnessProperty[A: Comparable[A] #read, R: RndCase[A] val] is Property1[(A, A)]
+class iso _RandomnessProperty[A: Comparable[A] #read, R: _RandomCase[A] val] is Property1[(A, A)]
   """
   Ensure Randomness generates a random number within the given range.
   """

--- a/ponycheck/_test.pony
+++ b/ponycheck/_test.pony
@@ -1396,7 +1396,7 @@ primitive RndCaseILong is RndCase[ILong]
 
 class iso _RandomnessProperty[A: Comparable[A] #read, R: RndCase[A] val] is Property1[(A, A)]
   """
-  ensure Randomnes generates random numer within the given range 
+  Ensure Randomness generates a random number within the given range.
   """
   let _type_name: String
 

--- a/ponycheck/randomness.pony
+++ b/ponycheck/randomness.pony
@@ -63,12 +63,12 @@ class ref Randomness
     if (min == U64.min_value()) and (max == U64.max_value()) then
       _random.u64()
     elseif min > U32.max_value().u64() then
-      (u32((min >> 32).u32(), (max >> 32).u32()).u64() << 32) or _random.next()
+      (u32((min >> 32).u32(), (max >> 32).u32()).u64() << 32) or _random.u32().u64()
     elseif max > U32.max_value().u64() then
       let high = (u32((min >> 32).u32(), (max >> 32).u32()).u64() << 32).u64()
       let low =
         if high > 0 then
-          _random.next()
+          _random.u32().u64()
         else
           u32(min.u32(), U32.max_value()).u64()
         end


### PR DESCRIPTION
Hello. I found that `Randomnes.u64()` can return random numbers outside the range when specified. 

I also added some tests to make sure that other methods are not affected. I tried to reduce the copy-pasting making them generic, but maybe there is a better and shorter way how to do it.