### PR TITLE
Update for change in type of Env.root

### DIFF
--- a/.release-notes/env-root.md
+++ b/.release-notes/env-root.md
@@ -1,0 +1,5 @@
+## Update to work with latest ponyc
+
+The most recent ponyc implements [RFC #65](https://github.com/ponylang/rfcs/blob/main/text/0065-env-root-not-optional.md) which changes the type of `Env.root`.
+
+We've updated accordingly. You won't be able to use this and future versions of the library without a corresponding update to your ponyc version.

--- a/examples/async_tcp_property.pony
+++ b/examples/async_tcp_property.pony
@@ -123,11 +123,11 @@ class _AsyncTCPSenderProperty is Property1[String]
   fun gen(): Generator[String] =>
     Generators.unicode()
 
-  fun ref property(sample: String, ph: PropertyHelper) ? =>
-    let sender = TCPSender(ph.env.root as AmbientAuth)
+  fun ref property(sample: String, ph: PropertyHelper) =>
+    let sender = TCPSender(ph.env.root)
     ph.dispose_when_done(
       TCPListener(
-        ph.env.root as AmbientAuth,
+        ph.env.root,
         recover MyTCPListenNotify(sender, ph, "PONYCHECK") end,
         "127.0.0.1",
         "0"))


### PR DESCRIPTION
The type of Env.root was changed as part of RFC #65:

https://github.com/ponylang/rfcs/blob/main/text/0065-env-root-not-optional.md

Shouldn't be merged until https://github.com/ponylang/ponyc/pull/3962 is merged